### PR TITLE
added mixing state to observabels which are written into tuple

### DIFF
--- a/configs/Bd2Dpi_SignalOnly_config.info
+++ b/configs/Bd2Dpi_SignalOnly_config.info
@@ -154,6 +154,15 @@ Observables {
       "B"  +1
     }
   }
+  mix_true {
+    name          "catMixingTrue"
+    desc          "Xi'"
+    type          Integer
+    range {
+      "mixed" -1
+      "unmixed"  +1
+    }
+  }
   tag_OS {
     name          "obsTagOS"
     desc          "d_{OS}"

--- a/src/generator/BSig_CPV_P2VP_Generator.cpp
+++ b/src/generator/BSig_CPV_P2VP_Generator.cpp
@@ -107,7 +107,7 @@ bool BSig_CPV_P2VP_Generator::TryGenerateEvent(TRandom& rndm, Observables& obser
   gen_success &= GenerateMass(rndm, observables.mass_true, observables.mass_meas);
   //gen_success &= GenerateLognormal(rndm, m, k, observables.timeerror);
   gen_success &= GenerateTimeAndTrueTag(rndm, observables.time_true, observables.timeerror, observables.tag_true,
-                                              observables.time_meas, observables.finalstate);
+                                              observables.time_meas, observables.finalstate, observables.mix_true);
   gen_success &= GenerateTagAndEta(rndm, observables.tag_true,
                     observables.tag_OS, observables.eta_OS,
                     observables.tag_SS, observables.eta_SS,
@@ -143,7 +143,7 @@ bool BSig_CPV_P2VP_Generator::GenerateMass(TRandom& rndm, ObservableReal& obs_ma
   return gen_success;
 }
 
-bool BSig_CPV_P2VP_Generator::GenerateTimeAndTrueTag(TRandom& rndm, ObservableReal& obs_time_true, ObservableReal& obs_timeerror, ObservableInt& obs_tag_true, ObservableReal& obs_time_meas, ObservableInt& obs_finalstate) {
+bool BSig_CPV_P2VP_Generator::GenerateTimeAndTrueTag(TRandom& rndm, ObservableReal& obs_time_true, ObservableReal& obs_timeerror, ObservableInt& obs_tag_true, ObservableReal& obs_time_meas, ObservableInt& obs_finalstate, ObservableInt& obs_mix_true) {
   unsigned int trials = 0;
   bool gen_success = true;
   while (trials < max_trials_) {
@@ -152,7 +152,7 @@ bool BSig_CPV_P2VP_Generator::GenerateTimeAndTrueTag(TRandom& rndm, ObservableRe
                      params_timeandcp_.dGamma, params_timeandcp_.dm,
                      params_timeandcp_.Sf, params_timeandcp_.Cf, params_timeandcp_.Df,
                      params_timeandcp_.Sfbar, params_timeandcp_.Cfbar, params_timeandcp_.Dfbar,
-                     obs_time_true.value_, obs_tag_true.value_, obs_finalstate.value_);
+                     obs_time_true.value_, obs_tag_true.value_, obs_finalstate.value_, obs_mix_true.value_);
 
     gen_success &= GenerateLognormal(rndm, params_timeresol_.lognormal_m, params_timeresol_.lognormal_k, obs_timeerror.min_value(), obs_timeerror.max_value(), obs_timeerror.value_);
     gen_success &= GenerateResolSingleGaussPerEvent(rndm, params_timeresol_.bias, params_timeresol_.scale, obs_timeerror.value_,

--- a/src/generator/BSig_CPV_P2VP_Generator.h
+++ b/src/generator/BSig_CPV_P2VP_Generator.h
@@ -28,7 +28,7 @@ public:
 
 private:
   bool GenerateMass(TRandom& rndm, ObservableReal& obs_mass_true, ObservableReal& obs_mass_meas);
-  bool GenerateTimeAndTrueTag(TRandom& rndm, ObservableReal& obs_time_true, ObservableReal& obs_timeerror, ObservableInt& obs_tag_true, ObservableReal& obs_time_meas, ObservableInt& finalstate);
+  bool GenerateTimeAndTrueTag(TRandom& rndm, ObservableReal& obs_time_true, ObservableReal& obs_timeerror, ObservableInt& obs_tag_true, ObservableReal& obs_time_meas, ObservableInt& finalstate, ObservableInt& mix_true);
   bool GenerateTagAndEta(TRandom& rndm, const ObservableInt& obs_tag_true,
                          ObservableInt& obs_tag_OS, ObservableReal& obs_eta_OS,
                          ObservableInt& obs_tag_SS, ObservableReal& obs_eta_SS,

--- a/src/generator/Bkg_2Final_Generator.cpp
+++ b/src/generator/Bkg_2Final_Generator.cpp
@@ -76,7 +76,7 @@ bool Bkg_2Final_Generator::TryGenerateEvent(TRandom& rndm, Observables& observab
 
   gen_success &= GenerateMass(rndm, observables.mass_true, observables.mass_meas);
   gen_success &= GenerateTimeAndTrueTag(rndm, observables.time_true, observables.timeerror, observables.tag_true,
-                                              observables.finalstate, observables.time_meas);
+                                              observables.finalstate, observables.time_meas, observables.mix_true);
   gen_success &= GenerateTagAndEta(rndm, observables.tag_true,
                                    observables.tag_OS, observables.eta_OS,
                                    observables.tag_SS, observables.eta_SS,
@@ -95,7 +95,8 @@ bool Bkg_2Final_Generator::GenerateMass(TRandom& rndm, ObservableReal& obs_mass_
 }
 
 bool Bkg_2Final_Generator::GenerateTimeAndTrueTag(TRandom& rndm, ObservableReal& obs_time_true, ObservableReal& obs_timeerror, ObservableInt&
-                                             obs_tag_true, ObservableInt& obs_finalstate, ObservableReal& obs_time_meas) {
+                                             obs_tag_true, ObservableInt& obs_finalstate, ObservableReal& obs_time_meas,
+                                             ObservableInt& obs_mix_true) {
 
   unsigned int trials = 0;
   bool gen_success = true;
@@ -108,6 +109,8 @@ bool Bkg_2Final_Generator::GenerateTimeAndTrueTag(TRandom& rndm, ObservableReal&
 
     // finalstate according to detasym
     obs_finalstate.value_ = (rndm.Uniform() < (1. - params_timeandcp_.det_asym)/2.) ? +1 : -1;
+
+    obs_mix_true.value_ = obs_tag_true.value_ * obs_finalstate.value_;
 
     // decay time
     gen_success &= GenerateExpo(rndm,1./params_timeandcp_.tau,obs_time_true.value_,obs_time_true.min_value(),obs_time_true.max_value());

--- a/src/generator/Bkg_2Final_Generator.h
+++ b/src/generator/Bkg_2Final_Generator.h
@@ -28,7 +28,8 @@ public:
 private:
   bool GenerateMass(TRandom& rndm, ObservableReal& obs_mass_true, ObservableReal& obs_mass_meas);
   bool GenerateTimeAndTrueTag(TRandom& rndm, ObservableReal& obs_time_true, ObservableReal& obs_timeerror,
-                              ObservableInt& obs_tag_true, ObservableInt& obs_finalstate, ObservableReal& obs_time_meas);
+                              ObservableInt& obs_tag_true, ObservableInt& obs_finalstate, ObservableReal& obs_time_meas,
+                              ObservableInt& obs_mix_true);
   bool GenerateTagAndEta(TRandom& rndm, const ObservableInt& obs_tag_true,
                          ObservableInt& obs_tag_OS, ObservableReal& obs_eta_OS,
                          ObservableInt& obs_tag_SS, ObservableReal& obs_eta_SS,

--- a/src/generator/Observables.cpp
+++ b/src/generator/Observables.cpp
@@ -53,6 +53,7 @@ Observables::Observables() :
   eta_SS("eta_SS","obsEtaSS","\\eta_{\\text{SS}}",0.5,0.0,0.5),
   comp_cat("comp_cat","catBkg","catBkg",-10000,{{"Sig_Bd",1},{"Sig_Bs",10},{"Bkg",100}}),
   finalstate("finalstate","catFinalstate","catFinalstate",1,{{"f",1},{"fbar",-1}}),
+  mix_true("mix_true","catMixingTrue","catMixingTrue",-99,{{"mixed",1},{"unmixed",-1}}),
   observables_real_(),
   observables_int_()
 {
@@ -70,6 +71,7 @@ Observables::Observables() :
   observables_int_.emplace(tag_SS.dim_name()    , &tag_SS    );
   observables_int_.emplace(comp_cat.dim_name()  , &comp_cat  );
   observables_int_.emplace(finalstate.dim_name(), &finalstate);
+  observables_int_.emplace(mix_true.dim_name(), &mix_true);
 }
 
 void Observables::Configure(const std::shared_ptr<configuration::ObsConfig> obs_config) {

--- a/src/generator/Observables.h
+++ b/src/generator/Observables.h
@@ -151,6 +151,7 @@ public:
   ObservableReal eta_SS;
   ObservableInt  comp_cat;
   ObservableInt finalstate;
+  ObservableInt mix_true;
 
 private:
   std::map<std::string,ObservableReal*> observables_real_;

--- a/src/generator/generator.cpp
+++ b/src/generator/generator.cpp
@@ -57,7 +57,8 @@ bool GenerateCPV_P2PV(TRandom& rndm, double par_prod_asym, double par_det_asym,
                       double par_tau, double par_dGamma, double par_dm,
                       double par_Sf, double par_Cf, double par_Df,
                       double par_Sfbar, double par_Cfbar, double par_Dfbar,
-                      double& obs_time_true, int& obs_tag_true, int& finalstate) {
+                      double& obs_time_true, int& obs_tag_true, int& finalstate,
+                      int& mix_true) {
   // helper quantities
   double prob_B = (1. - par_prod_asym)/2.;
   double gamma_min = 1./par_tau - std::abs(par_dGamma)/2.;
@@ -116,6 +117,7 @@ bool GenerateCPV_P2PV(TRandom& rndm, double par_prod_asym, double par_det_asym,
   obs_tag_true  = val_d;
   obs_time_true = val_t;
   finalstate    = val_final;
+  mix_true      = val_final * val_d;
 
   return true;
 }

--- a/src/generator/generator.h
+++ b/src/generator/generator.h
@@ -36,7 +36,8 @@ bool GenerateCPV_P2PV(TRandom& rndm, double par_prod_asym, double par_det_asym,
                       double par_tau, double par_dGamma, double par_dm,
                       double par_Sf, double par_Cf, double par_Df,
                       double par_Sfbar, double par_Cfbar, double par_Dfbar,
-                      double& obs_time_true, int& obs_tag_true, int& finalstate);
+                      double& obs_time_true, int& obs_tag_true, int& finalstate,
+                      int& mix_true);
 
 double BCPV_PDF(double t, double d, double tau, double dGamma, double dm,
                 double Sf, double Cf, double Df);


### PR DESCRIPTION
In the case of two final states the information of the mixing state is an interesting physical observable. As it is not that easy to multiply RooCategories inside a RooDataSet as a first step the true mixing state (based on the true tag and the finalstate) is written into the generated root-tuple. In case only one finalstate is generated the default value for the mixing state is -99, so it should hopefully not lead to too large confusion