### PR TITLE
updated config for Bd2Dpi to generate 'correct' resolution

### DIFF
--- a/configs/Bd2Dpi_SignalOnly_config.info
+++ b/configs/Bd2Dpi_SignalOnly_config.info
@@ -36,7 +36,7 @@ Components
       }
       TimeResol {
         bias  0.
-        sigma 0.050
+        sigma 0.05491
       }
       Tagging {
         eff_OS     1.0
@@ -76,7 +76,8 @@ Components
       }
       TimeResol {
         bias  0.
-        sigma 0.050
+        sigma 0.05491
+        scale 1.0
       }
       Tagging {
         eff_OS    0.3292
@@ -134,6 +135,13 @@ Observables {
     type          Real
     min           -2.
     max           20.
+  }
+  timeerror {
+    name          "obsTimeErr"
+    desc          "s_t"
+    type          Real
+    min           0.05491
+    max           0.05491
   }
   finalstate {
     name             "catFinalstate"


### PR DESCRIPTION
with the "new" config now the "correct" average resolution, defined in the observable time_err is generated 